### PR TITLE
add `*.gif` to package_data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
             'htdocs/fonts/*.*',
             'htdocs/js/*.js',
             'htdocs/*.png',
+            'htdocs/*.gif',
         ]},
     install_requires = ['TracThemeEngine'],
     entry_points = {


### PR DESCRIPTION
`python setup.py install` dosen't copy `htdocs/*.gif` files, because `package_data` donsen't contain `*.gif`.